### PR TITLE
add compatibility for react-navigation v5 without API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This library provides the core API, types and mobile files for packages such as `expo-gatbsy-navigation` and `expo-next-react-navigation`.
 
 It won't be used directly in projects, rather it provides the starting point for expo web navigation libraries.
+
+**React Navigation v4 is no longer being maintained.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149",
+    "@types/lodash.get": "^4.4.6",
     "@types/react": "^16.9.16",
     "eslint": "^6.8.0",
     "eslint-config-universe": "^2.1.0",
@@ -40,6 +41,6 @@
   },
   "dependencies": {
     "@react-navigation/native": "^5.0.0-alpha.29",
-    "lodash": "^4.17.15"
+    "lodash.get": "^4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-navigation-core",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "Main package for reusable expo navigation elements. This package probably shouldn't be installed on its own.",
   "sideEffects": true,
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "expo-module test",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
-    "expo-module": "expo-module"
+    "expo-module": "expo-module",
+    "upload": "yarn publish --tag v5"
   },
   "files": [
     "build"
@@ -38,7 +39,7 @@
     "react-native-web": "^0.11.7"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
-    "react-navigation-hooks": "^1.1.0"
+    "@react-navigation/native": "^5.0.0-alpha.29",
+    "lodash": "^4.17.15"
   }
 }

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -57,7 +57,7 @@ const LinkMaker = <
       return (
         <TouchableOpacity {...touchableOpacityProps} onPress={nav}>
           {isText ? (
-            <Text style={props.style} accessibiltyRole="link">
+            <Text ref={ref} style={props.style} accessibiltyRole="link">
               {children}
             </Text>
           ) : (

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react'
 import { TouchableOpacity, Text } from 'react-native'
 import useRouting from '../../hooks/use-routing'
 import empty from '../../utils/empty'
-import { LinkProps } from '..'
+import { NavigateTo } from '../../hooks'
+import { LinkProps } from '../Link/types'
 
 // I made this an "HOC" of sorts to let us both use TS generics for each lib and React.forwardRef
 
@@ -16,10 +17,10 @@ import { LinkProps } from '..'
  * import { ExtraLinkProps, GatsbyWebProps } from './types'
  *
  * const Link = React.forwardRef(
- * (
+ * function Link(
  * 	props: LinkProps<ExtraLinkProps, GatsbyWebProps>,
  * 	ref?: React.Ref<Text>
- * ) => {
+ * ) {
  * 	const Link = LinkMaker<ExtraLinkProps, GatsbyWebProps>()
  * 	return <Link {...props} ref={ref} />
  * }
@@ -32,10 +33,16 @@ import { LinkProps } from '..'
 const LinkMaker = <
   ExtraProps extends object = {},
   Web extends object = {},
+  Native extends Required<NavigateTo>['native'] = Required<
+    NavigateTo
+  >['native'],
   Params extends object = {}
 >() =>
   React.forwardRef(
-    (props: LinkProps<ExtraProps, Web, Params>, ref?: React.Ref<Text>) => {
+    (
+      props: LinkProps<ExtraProps, Web, Native, Params>,
+      ref?: React.Ref<Text>
+    ) => {
       const { navigate } = useRouting()
       const {
         touchableOpacityProps = empty.object,
@@ -43,16 +50,16 @@ const LinkMaker = <
         params,
         children,
         isText = true,
+        native,
       } = props
 
-      const nav = useCallback(
-        () =>
-          navigate({
-            routeName: routeName || '/',
-            params,
-          }),
-        [navigate, routeName, params]
-      )
+      const nav = useCallback(() => {
+        navigate({
+          routeName: routeName || '/',
+          params,
+          native,
+        })
+      }, [navigate, routeName, params])
 
       return (
         <TouchableOpacity {...touchableOpacityProps} onPress={nav}>

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -42,6 +42,7 @@ const LinkMaker = <
         routeName,
         params,
         children,
+        isText = true,
       } = props
 
       const nav = useCallback(
@@ -55,9 +56,13 @@ const LinkMaker = <
 
       return (
         <TouchableOpacity {...touchableOpacityProps} onPress={nav}>
-          <Text style={props.style} accessibiltyRole="link">
-            {children}
-          </Text>
+          {isText ? (
+            <Text style={props.style} accessibiltyRole="link">
+              {children}
+            </Text>
+          ) : (
+            children
+          )}
         </TouchableOpacity>
       )
     }

--- a/src/components/Link/types.ts
+++ b/src/components/Link/types.ts
@@ -27,4 +27,11 @@ export type LinkProps<
    */
   params?: Params
   web?: Web
+  /**
+   * If false, it will not automatically wrap the children with a `Text` node.
+   * This is useful if you want to use a link around something other than text.
+   *
+   * Default: `true`
+   */
+  isText?: boolean
 } & ExtraProps

--- a/src/components/Link/types.ts
+++ b/src/components/Link/types.ts
@@ -1,9 +1,11 @@
 import { TouchableOpacity, TextStyle } from 'react-native'
 import { ComponentPropsWithoutRef } from 'react'
+import { NavigateTo } from '../../hooks'
 
 export type LinkProps<
   ExtraProps extends object = {},
   Web extends object = {},
+  Native extends object = Required<NavigateTo>['native'],
   Params extends object = {}
 > = {
   /**
@@ -34,4 +36,5 @@ export type LinkProps<
    * Default: `true`
    */
   isText?: boolean
+  native?: Native
 } & ExtraProps

--- a/src/hooks/use-focus-effect/index.ts
+++ b/src/hooks/use-focus-effect/index.ts
@@ -1,1 +1,1 @@
-export { useFocusEffect as default } from 'react-navigation-hooks'
+export { useFocusEffect as default } from '@react-navigation/native'

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -19,6 +19,7 @@ export default function useRouting<
     replace: rep,
     setParams,
     dispatch,
+    canGoBack,
   } = useNavigation<NProp>()
 
   const { params } = useRoute<RProp>()
@@ -68,5 +69,6 @@ export default function useRouting<
     popToTop,
     replace,
     setParams,
+    canGoBack,
   }
 }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -1,8 +1,7 @@
 import { useNavigation, useRoute } from '@react-navigation/native'
 import { useCallback } from 'react'
-import * as _ from 'lodash'
-import { NavigateTo } from '..'
-import { DefaultRouteProp, DefaultNavigationProp } from './types'
+import get from 'lodash.get'
+import { DefaultRouteProp, DefaultNavigationProp, NavigateTo } from './types'
 
 const prefetch = (routeName: string) => {}
 
@@ -19,17 +18,26 @@ export default function useRouting<
     popToTop,
     replace: rep,
     setParams,
+    dispatch,
   } = useNavigation<NProp>()
 
   const { params } = useRoute<RProp>()
 
   const navigate = useCallback(
     <To extends NavigateTo = NavigateTo>(route: To) => {
-      nav({
-        name: route.routeName,
-        params: route.params,
-        key: route.key,
-      })
+      if (route?.native?.screen) {
+        nav(route.routeName, {
+          screen: route.native.screen,
+          params: route.params,
+          key: route.key,
+        })
+      } else {
+        nav({
+          name: route.routeName,
+          params: route.params,
+          key: route.key,
+        })
+      }
     },
     [nav]
   )
@@ -41,7 +49,7 @@ export default function useRouting<
     [pushTo, navigate]
   )
   const getParam = <Param>(param: string, fallback?: unknown): Param => {
-    return _.get(params, param, fallback)
+    return get(params, param, fallback)
   }
   const replace = useCallback(
     <To extends NavigateTo = NavigateTo>({ routeName, params }: To) => {

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -39,5 +39,5 @@ export default function useRouting<
     return _.get(params, param, fallback)
   }
 
-  return { navigate, getParam, push, goBack: () => goBack() }
+  return { navigate, getParam, push, goBack: () => goBack(), params }
 }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -19,9 +19,13 @@ export default function useRouting<
   NProp extends NavigationProp<ParamListBase> = NavigationProp<ParamListBase>
 >() {
   // @ts-ignore
-  const { navigate: nav, push: pushTo, goBack, popToTop } = useNavigation<
-    NProp
-  >()
+  const {
+    navigate: nav,
+    push: pushTo,
+    goBack,
+    popToTop,
+    replace: rep,
+  } = useNavigation<NProp>()
 
   const { params } = useRoute<RProp>()
 
@@ -45,6 +49,12 @@ export default function useRouting<
   const getParam = <Param>(param: string, fallback?: unknown): Param => {
     return _.get(params, param, fallback)
   }
+  const replace = useCallback(
+    <To extends NavigateTo = NavigateTo>(route: To) => {
+      rep(route.routeName, route.params)
+    },
+    [rep]
+  )
 
   return {
     navigate,
@@ -54,5 +64,6 @@ export default function useRouting<
     params,
     prefetch,
     popToTop,
+    replace,
   }
 }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -9,14 +9,16 @@ import { useCallback } from 'react'
 import _ from 'lodash'
 import { NavigateTo } from '..'
 
+const prefetch = (routeName: string) => {}
+
 export default function useRouting<
-  T extends RouteProp<ParamListBase, string>,
-  N extends NavigationProp<ParamListBase>
+  RProp extends RouteProp<ParamListBase, string>,
+  NProp extends NavigationProp<ParamListBase>
 >() {
   // @ts-ignore
-  const { navigate: nav, push: pushTo, goBack } = useNavigation<N>()
+  const { navigate: nav, push: pushTo, goBack } = useNavigation<NProp>()
 
-  const { params } = useRoute<T>()
+  const { params } = useRoute<RProp>()
 
   const navigate = useCallback(
     <To extends NavigateTo = NavigateTo>(route: To) => {
@@ -39,5 +41,5 @@ export default function useRouting<
     return _.get(params, param, fallback)
   }
 
-  return { navigate, getParam, push, goBack: () => goBack(), params }
+  return { navigate, getParam, push, goBack: () => goBack(), params, prefetch }
 }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -70,5 +70,6 @@ export default function useRouting<
     replace,
     setParams,
     canGoBack,
+    pathname: '',
   }
 }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -1,33 +1,40 @@
-import { useNavigation } from 'react-navigation-hooks'
+import {
+  useNavigation,
+  useRoute,
+  RouteProp,
+  ParamListBase,
+  NavigationProp,
+} from '@react-navigation/native'
 import { useCallback } from 'react'
+import _ from 'lodash'
 import { NavigateTo } from '..'
 
-export default function useRouting() {
-  const {
-    navigate: nav,
-    getParam: grabParam,
-    push: pushTo,
-    goBack,
-  } = useNavigation()
+export default function useRouting<
+  T extends RouteProp<ParamListBase, string>,
+  N extends NavigationProp<ParamListBase>
+>() {
+  const { navigate: nav, push: pushTo, goBack } = useNavigation<N>()
+
+  const { params } = useRoute<T>()
 
   const navigate = useCallback(
     <To extends NavigateTo = NavigateTo>(route: To) => {
       nav({
-        routeName: route.routeName,
+        name: route.routeName,
         params: route.params,
+        key: route.key,
       })
     },
     [nav]
   )
   const push = useCallback(
     <To extends NavigateTo = NavigateTo>(route: To) => {
-      pushTo(route)
+      pushTo && pushTo(route)
     },
     [pushTo]
   )
   const getParam = <Param>(param: string, fallback?: unknown): Param => {
-    const value: Param = grabParam(param, fallback)
-    return value
+    return _.get(params, param, fallback)
   }
 
   return { navigate, getParam, push, goBack: () => goBack() }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -13,6 +13,7 @@ export default function useRouting<
   T extends RouteProp<ParamListBase, string>,
   N extends NavigationProp<ParamListBase>
 >() {
+  // @ts-ignore
   const { navigate: nav, push: pushTo, goBack } = useNavigation<N>()
 
   const { params } = useRoute<T>()
@@ -29,9 +30,10 @@ export default function useRouting<
   )
   const push = useCallback(
     <To extends NavigateTo = NavigateTo>(route: To) => {
-      pushTo && pushTo(route)
+      if (pushTo) pushTo(route)
+      else navigate<To>(route)
     },
-    [pushTo]
+    [pushTo, navigate]
   )
   const getParam = <Param>(param: string, fallback?: unknown): Param => {
     return _.get(params, param, fallback)

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -12,11 +12,16 @@ import { NavigateTo } from '..'
 const prefetch = (routeName: string) => {}
 
 export default function useRouting<
-  RProp extends RouteProp<ParamListBase, string>,
-  NProp extends NavigationProp<ParamListBase>
+  RProp extends RouteProp<ParamListBase, string> = RouteProp<
+    ParamListBase,
+    string
+  >,
+  NProp extends NavigationProp<ParamListBase> = NavigationProp<ParamListBase>
 >() {
   // @ts-ignore
-  const { navigate: nav, push: pushTo, goBack } = useNavigation<NProp>()
+  const { navigate: nav, push: pushTo, goBack, popToTop } = useNavigation<
+    NProp
+  >()
 
   const { params } = useRoute<RProp>()
 
@@ -41,5 +46,13 @@ export default function useRouting<
     return _.get(params, param, fallback)
   }
 
-  return { navigate, getParam, push, goBack: () => goBack(), params, prefetch }
+  return {
+    navigate,
+    getParam,
+    push,
+    goBack: () => goBack(),
+    params,
+    prefetch,
+    popToTop,
+  }
 }

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -1,30 +1,24 @@
-import {
-  useNavigation,
-  useRoute,
-  RouteProp,
-  ParamListBase,
-  NavigationProp,
-} from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import { useCallback } from 'react'
-import _ from 'lodash'
+import * as _ from 'lodash'
 import { NavigateTo } from '..'
+import { DefaultRouteProp, DefaultNavigationProp } from './types'
 
 const prefetch = (routeName: string) => {}
 
 export default function useRouting<
-  RProp extends RouteProp<ParamListBase, string> = RouteProp<
-    ParamListBase,
-    string
-  >,
-  NProp extends NavigationProp<ParamListBase> = NavigationProp<ParamListBase>
+  RProp extends DefaultRouteProp = DefaultRouteProp,
+  NProp extends DefaultNavigationProp = DefaultNavigationProp
 >() {
-  // @ts-ignore
   const {
     navigate: nav,
+    // @ts-ignore
     push: pushTo,
     goBack,
+    // @ts-ignore
     popToTop,
     replace: rep,
+    setParams,
   } = useNavigation<NProp>()
 
   const { params } = useRoute<RProp>()
@@ -50,8 +44,8 @@ export default function useRouting<
     return _.get(params, param, fallback)
   }
   const replace = useCallback(
-    <To extends NavigateTo = NavigateTo>(route: To) => {
-      rep(route.routeName, route.params)
+    <To extends NavigateTo = NavigateTo>({ routeName, params }: To) => {
+      rep(routeName, params)
     },
     [rep]
   )
@@ -65,5 +59,6 @@ export default function useRouting<
     prefetch,
     popToTop,
     replace,
+    setParams,
   }
 }

--- a/src/hooks/use-routing/types.ts
+++ b/src/hooks/use-routing/types.ts
@@ -49,6 +49,10 @@ type GenericRoute = {
      * Should start with `/`.
      */
     as?: string
+    /**
+     * Should use shallow routing.
+     */
+    shallow?: boolean
   }
   native?: {
     /**

--- a/src/hooks/use-routing/types.ts
+++ b/src/hooks/use-routing/types.ts
@@ -1,3 +1,11 @@
+import {
+  useNavigation,
+  useRoute,
+  RouteProp,
+  ParamListBase,
+  NavigationProp,
+} from '@react-navigation/native'
+
 type GenericRoute = {
   /**
    * React navigation route & web page URL extension
@@ -45,3 +53,6 @@ type GenericRoute = {
 }
 
 export type NavigateTo = GenericRoute
+
+export type DefaultRouteProp = RouteProp<ParamListBase, string>
+export type DefaultNavigationProp = NavigationProp<ParamListBase>

--- a/src/hooks/use-routing/types.ts
+++ b/src/hooks/use-routing/types.ts
@@ -3,6 +3,7 @@ type GenericRoute = {
    * React navigation route & web page URL extension
    */
   routeName: string
+  key?: string
   /**
    * (optional) Dictionary that will be accessed via `getParams` in the target screen.
    */

--- a/src/hooks/use-routing/types.ts
+++ b/src/hooks/use-routing/types.ts
@@ -50,6 +50,14 @@ type GenericRoute = {
      */
     as?: string
   }
+  native?: {
+    /**
+     * Used for a nested screen in your navigator.
+     *
+     * See React Navigation's docs: https://reactnavigation.org/docs/nesting-navigators/#passing-params-to-a-screen-in-a-nested-navigator
+     */
+    screen?: string
+  }
 }
 
 export type NavigateTo = GenericRoute

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,6 +1150,24 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-navigation/core@^5.0.0-alpha.37":
+  version "5.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.0.0-alpha.37.tgz#0e91dc2f1d46d646a5d63f882dc3c18a9e74a2cf"
+  integrity sha512-lTk7yx9jqzK3+yRxX+yz8v+1uw9aOaX1LfQFPpgwyJUAjQdZU9qqigSd/qZHtaOSg5XCOacjO+G4Qk9/hNp+Ag==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+    query-string "^6.9.0"
+    react-is "^16.12.0"
+    shortid "^2.2.15"
+    use-subscription "^1.3.0"
+
+"@react-navigation/native@^5.0.0-alpha.29":
+  version "5.0.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.0.0-alpha.29.tgz#0b286aaf8d15868766513f58b2b1fc45a1559d8b"
+  integrity sha512-Axd9stTTc4MVNwXvU356UNi+svEmOhB3f98YD68IJpkck6+wT1qMN4kgP2tBaA4FFON8VtxQnc2Sz9+FroXnfg==
+  dependencies:
+    "@react-navigation/core" "^5.0.0-alpha.37"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -2777,6 +2795,11 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escodegen@^1.9.1:
   version "1.12.1"
@@ -5405,6 +5428,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.0:
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.10.tgz#66fb5ac664ee2d3017f451b9f0d26cfec3c034b5"
+  integrity sha512-ZPUHBAwrQ+BSwVV2Xh6hBOEStTzAf8LgohOY0kk22lDiDdI32582KjVPYCqgqj7834hTunGzwZOB4me9T6ZcnA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6114,6 +6142,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.9.0:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.10.1.tgz#30b3505f6fca741d5ae541964d1b3ae9dc2a0de8"
+  integrity sha512-SHTUV6gDlgMXg/AQUuLpTiBtW/etZ9JT6k6RCtCyqADquApLX0Aq5oK/s5UeTUAWBG50IExjIr587GqfXRfM4A==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -6216,11 +6253,6 @@ react-native-web@^0.11.7:
     scheduler "0.15.0"
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
-
-react-navigation-hooks@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-navigation-hooks/-/react-navigation-hooks-1.1.0.tgz#337c41a50ebc7b9030bb9d9333cd4fd6e1f86b68"
-  integrity sha512-ZY/aiYJ88KXaOo8iOa4171O/0x6ztGhUPd2OYzdaJhLT/tP64zi5HB/RZFImuKhaBTODXjoSpFaOTA5xpePG4g==
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -6806,6 +6838,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shortid@^2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6939,6 +6978,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -7000,6 +7044,11 @@ stream-buffers@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -7453,6 +7502,13 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-subscription@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.3.0.tgz#3df13a798e826c8d462899423293289a3362e4e6"
+  integrity sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==
+  dependencies:
+    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,6 +1238,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/lodash.get@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
+  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.162"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.162.tgz#65d78c397e0d883f44afbf1f7ba9867022411470"
+  integrity sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==
+
 "@types/lodash@^4.14.149":
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
@@ -4852,6 +4864,11 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Addresses: https://github.com/nandorojo/expo-next-react-navigation/issues/, https://github.com/nandorojo/expo-gatsby-navigation/issues/3 and https://github.com/nandorojo/expo-gatsby-navigation/issues/2

There are a few changes here which add compatibility for `react-navigation` v5.

```
yarn add expo-navigation-core@v5
```

To use in other projects (like `expo-gatsby-navigation` and `expo-next-react-navigation`), I'll also publish those with a `@v5` flag.

