### PR TITLE
Wrap Text component around children only if isText prop is true

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -42,6 +42,7 @@ const LinkMaker = <
         routeName,
         params,
         children,
+        isText = true,
       } = props
 
       const nav = useCallback(
@@ -55,9 +56,13 @@ const LinkMaker = <
 
       return (
         <TouchableOpacity {...touchableOpacityProps} onPress={nav}>
-          <Text style={props.style} accessibiltyRole="link">
-            {children}
-          </Text>
+          {isText ? (
+            <Text style={props.style} accessibiltyRole="link">
+              {children}
+            </Text>
+          ) : (
+            children
+          )}
         </TouchableOpacity>
       )
     }

--- a/src/components/Link/types.ts
+++ b/src/components/Link/types.ts
@@ -27,4 +27,11 @@ export type LinkProps<
    */
   params?: Params
   web?: Web
+  /**
+   * If false, it will not automatically wrap the children with a `Text` node.
+   * This is useful if you want to use a link around something other than text.
+   *
+   * Default: `true`
+   */
+  isText?: boolean
 } & ExtraProps


### PR DESCRIPTION
## Why the change?
I'm using `Link` from `expo-next-react-navigation@v5` and I'd like to pass a `View` as a child. `Text` cannot have `View` as its child. This PR check the type of the children, and wraps with `<Text />` only if the child is `typeof string`.

cc: @nandorojo 

