### PR TITLE
add navigating to a nested navigator

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -41,6 +41,7 @@ const LinkMaker = <
         touchableOpacityProps = empty.object,
         routeName,
         params,
+        native,
         children,
         isText = true,
       } = props
@@ -50,6 +51,7 @@ const LinkMaker = <
           navigate({
             routeName: routeName || '/',
             params,
+            native,
           }),
         [navigate, routeName, params]
       )

--- a/src/components/Link/types.ts
+++ b/src/components/Link/types.ts
@@ -4,6 +4,7 @@ import { ComponentPropsWithoutRef } from 'react'
 export type LinkProps<
   ExtraProps extends object = {},
   Web extends object = {},
+  Native extends object = {},
   Params extends object = {}
 > = {
   /**
@@ -27,6 +28,7 @@ export type LinkProps<
    */
   params?: Params
   web?: Web
+  native?: Native
   /**
    * If false, it will not automatically wrap the children with a `Text` node.
    * This is useful if you want to use a link around something other than text.

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -1,8 +1,8 @@
 import { useNavigation, useRoute } from '@react-navigation/native'
 import { useCallback } from 'react'
 import * as _ from 'lodash'
-import { NavigateTo } from '..'
 import { DefaultRouteProp, DefaultNavigationProp } from './types'
+import { NavigateTo } from '..'
 
 const prefetch = (routeName: string) => {}
 

--- a/src/hooks/use-routing/index.ts
+++ b/src/hooks/use-routing/index.ts
@@ -25,11 +25,19 @@ export default function useRouting<
 
   const navigate = useCallback(
     <To extends NavigateTo = NavigateTo>(route: To) => {
-      nav({
-        name: route.routeName,
-        params: route.params,
-        key: route.key,
-      })
+      if (route?.native?.screen) {
+        nav(route.routeName, {
+          screen: route.native.screen,
+          params: route.params,
+          key: route.key,
+        })
+      } else {
+        nav({
+          name: route.routeName,
+          params: route.params,
+          key: route.key,
+        })
+      }
     },
     [nav]
   )

--- a/src/hooks/use-routing/types.ts
+++ b/src/hooks/use-routing/types.ts
@@ -1,6 +1,4 @@
 import {
-  useNavigation,
-  useRoute,
   RouteProp,
   ParamListBase,
   NavigationProp,

--- a/src/hooks/use-routing/types.ts
+++ b/src/hooks/use-routing/types.ts
@@ -50,6 +50,13 @@ type GenericRoute = {
      */
     as?: string
   }
+
+  native?: {
+    /**
+     * Nesting navigator screen on native.
+     */
+    screen?: string
+  }
 }
 
 export type NavigateTo = GenericRoute

--- a/src/utils/empty.ts
+++ b/src/utils/empty.ts
@@ -1,6 +1,6 @@
 const empty = {
-	object: {},
-	array: [],
+  object: {},
+  array: [],
 }
 
 export default empty


### PR DESCRIPTION
## Why the change?
[Navigating to a nested navigator · Issue #27 · nandorojo/expo-next-react-navigation](https://github.com/nandorojo/expo-next-react-navigation/issues/27)

- If you have a `native.screen`, change the argument of `navigate` in `useRouting`.
- Component should also match the above changes.
- fix lint warnings

cc: @nandorojo